### PR TITLE
Feature/command handler param

### DIFF
--- a/botx/bots/mixins/collecting/default.py
+++ b/botx/bots/mixins/collecting/default.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Optional, Sequence, Union
 
 from botx.collecting.collectors.collector import Collector
 from botx.dependencies.models import Depends
+from botx.models.command import CommandDescriptor
 
 
 class DefaultHandlerMixin:
@@ -20,6 +21,7 @@ class DefaultHandlerMixin:
         name: Optional[str] = None,
         description: Optional[str] = None,
         full_description: Optional[str] = None,
+        command_descriptor: Optional[CommandDescriptor] = None,
         include_in_status: Union[bool, Callable] = False,
         dependencies: Optional[Sequence[Depends]] = None,
         dependency_overrides_provider: Any = None,
@@ -38,6 +40,8 @@ class DefaultHandlerMixin:
             description: description for command that will be shown in bot's menu.
             full_description: full description that can be used for example in `/help`
                 command.
+            command_descriptor: parameter object including `command`, `commands`,
+                `name` and `description`. Separately passed any of these has priority
             include_in_status: should this handler be shown in bot's menu, can be
                 callable function with no arguments *(for now)*.
             dependencies: sequence of dependencies that should be executed before
@@ -54,6 +58,7 @@ class DefaultHandlerMixin:
             name=name,
             description=description,
             full_description=full_description,
+            command_descriptor=command_descriptor,
             include_in_status=include_in_status,
             dependencies=dependencies,
             dependency_overrides_provider=dependency_overrides_provider,

--- a/botx/bots/mixins/collecting/handler.py
+++ b/botx/bots/mixins/collecting/handler.py
@@ -40,6 +40,8 @@ class HandlerMixin:
             description: description for command that will be shown in bot's menu.
             full_description: full description that can be used for example in `/help`
                 command.
+            command_descriptor: parameter object including `command`, `commands`,
+                `name` and `description`. Separately passed any of these has priority
             include_in_status: should this handler be shown in bot's menu, can be
                 callable function with no arguments *(for now)*.
             dependencies: sequence of dependencies that should be executed before

--- a/botx/bots/mixins/collecting/handler.py
+++ b/botx/bots/mixins/collecting/handler.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Optional, Sequence, Union
 
 from botx.collecting.collectors.collector import Collector
 from botx.dependencies.models import Depends
+from botx.models.command import CommandDescriptor
 
 
 class HandlerMixin:
@@ -20,6 +21,7 @@ class HandlerMixin:
         name: Optional[str] = None,
         description: Optional[str] = None,
         full_description: Optional[str] = None,
+        command_descriptor: Optional[CommandDescriptor] = None,
         include_in_status: Union[bool, Callable] = True,
         dependencies: Optional[Sequence[Depends]] = None,
         dependency_overrides_provider: Any = None,
@@ -54,6 +56,7 @@ class HandlerMixin:
             name=name,
             description=description,
             full_description=full_description,
+            command_descriptor=command_descriptor,
             include_in_status=include_in_status,
             dependencies=dependencies,
             dependency_overrides_provider=dependency_overrides_provider,

--- a/botx/bots/mixins/collecting/hidden.py
+++ b/botx/bots/mixins/collecting/hidden.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Optional, Sequence
 
 from botx.collecting.collectors.collector import Collector
 from botx.dependencies.models import Depends
+from botx.models.command import CommandDescriptor
 
 
 class HiddenHandlerMixin:
@@ -18,6 +19,7 @@ class HiddenHandlerMixin:
         command: Optional[str] = None,
         commands: Optional[Sequence[str]] = None,
         name: Optional[str] = None,
+        command_descriptor: Optional[CommandDescriptor] = None,
         dependencies: Optional[Sequence[Depends]] = None,
         dependency_overrides_provider: Any = None,
     ) -> Callable:
@@ -28,6 +30,8 @@ class HiddenHandlerMixin:
             command: body template that will trigger this handler.
             commands: list of body templates that will trigger this handler.
             name: optional name for handler that will be used in generating body.
+            command_descriptor: parameter object including `command`, `commands`,
+                `name` and `description`. Separately passed any of these has priority
             dependencies: sequence of dependencies that should be executed before
                 handler.
             dependency_overrides_provider: mock of callable for handler.
@@ -40,6 +44,7 @@ class HiddenHandlerMixin:
             command=command,
             commands=commands,
             name=name,
+            command_descriptor=command_descriptor,
             dependencies=dependencies,
             dependency_overrides_provider=dependency_overrides_provider,
         )

--- a/botx/collecting/collectors/mixins/default.py
+++ b/botx/collecting/collectors/mixins/default.py
@@ -6,6 +6,7 @@ from botx.collecting.collectors.mixins.handler import HandlerDecoratorProtocol
 from botx.collecting.handlers.handler import Handler
 from botx.collecting.handlers.name_generators import get_name_from_callable
 from botx.dependencies.models import Depends
+from botx.models.command import CommandDescriptor
 
 try:
     from typing import Protocol  # noqa: WPS433
@@ -35,6 +36,7 @@ class DefaultHandlerMixin:
         description: Optional[str] = None,
         full_description: Optional[str] = None,
         include_in_status: Union[bool, Callable] = False,
+        command_descriptor: Optional[CommandDescriptor] = None,
         dependencies: Optional[Sequence[Depends]] = None,
         dependency_overrides_provider: Any = None,
     ) -> Callable:
@@ -78,6 +80,7 @@ class DefaultHandlerMixin:
                 description=description,
                 full_description=full_description,
                 include_in_status=include_in_status,
+                command_descriptor=command_descriptor,
                 dependencies=dependencies,
                 dependency_overrides_provider=dependency_overrides_provider,
             )
@@ -96,6 +99,7 @@ class DefaultHandlerMixin:
             description=description,
             full_description=full_description,
             include_in_status=include_in_status,
+            command_descriptor=command_descriptor,
             dependencies=dependencies,
             dependency_overrides_provider=dependency_overrides_provider,
         )

--- a/botx/collecting/collectors/mixins/handler.py
+++ b/botx/collecting/collectors/mixins/handler.py
@@ -24,7 +24,6 @@ class AddHandlerProtocol(Protocol):
         description: Optional[str] = None,
         full_description: Optional[str] = None,
         include_in_status: Union[bool, Callable] = True,
-        command_descriptor: Optional[CommandDescriptor] = None,
         dependencies: Optional[Sequence[Depends]] = None,
         dependency_overrides_provider: Any = None,
     ) -> None:
@@ -103,9 +102,9 @@ class HandlerMixin:
                 if name is None:
                     name = command_descriptor.name
                 if description is None:
-                    description = command_descriptor.description.short
+                    description = command_descriptor.description
                 if full_description is None:
-                    full_description = command_descriptor.description.full
+                    full_description = command_descriptor.full_description
 
             handler_commands: List[
                 Optional[str]

--- a/botx/collecting/collectors/mixins/hidden.py
+++ b/botx/collecting/collectors/mixins/hidden.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Optional, Sequence
 
 from botx.collecting.collectors.mixins.handler import HandlerDecoratorProtocol
 from botx.dependencies.models import Depends
+from botx.models.command import CommandDescriptor
 
 
 class HiddenHandlerMixin:
@@ -15,6 +16,7 @@ class HiddenHandlerMixin:
         command: Optional[str] = None,
         commands: Optional[Sequence[str]] = None,
         name: Optional[str] = None,
+        command_descriptor: Optional[CommandDescriptor] = None,
         dependencies: Optional[Sequence[Depends]] = None,
         dependency_overrides_provider: Any = None,
     ) -> Callable:
@@ -38,6 +40,7 @@ class HiddenHandlerMixin:
             commands=commands,
             name=name,
             include_in_status=False,
+            command_descriptor=command_descriptor,
             dependencies=dependencies,
             dependency_overrides_provider=dependency_overrides_provider,
         )

--- a/botx/collecting/collectors/mixins/hidden.py
+++ b/botx/collecting/collectors/mixins/hidden.py
@@ -27,6 +27,8 @@ class HiddenHandlerMixin:
             command: body template that will trigger this handler.
             commands: list of body templates that will trigger this handler.
             name: optional name for handler that will be used in generating body.
+            command_descriptor: parameter object including `command`, `commands`,
+                `name` and `description`. Separately passed any of these has priority.
             dependencies: sequence of dependencies that should be executed before
                 handler.
             dependency_overrides_provider: mock of callable for handler.

--- a/botx/models/command.py
+++ b/botx/models/command.py
@@ -1,14 +1,6 @@
 from typing import Optional, Sequence
 
-from pydantic import BaseModel, Field
-
-
-class CommandDescription(BaseModel):
-    #: command description that will be shown in a menu.
-    short: Optional[str] = None
-
-    #: full description that can be used for example in `/help`
-    full: Optional[str] = None
+from pydantic import BaseModel
 
 
 class CommandDescriptor(BaseModel):
@@ -27,10 +19,7 @@ class CommandDescriptor(BaseModel):
     name: Optional[str] = None
 
     #: command description that will be shown in a menu.
-    description: Optional[CommandDescription] = None
+    description: Optional[str] = None
 
-
-# For user-defined code
-BotCommand = CommandDescriptor
-Description = CommandDescription
-
+    #: full description that can be used for example in `/help`
+    full_description: Optional[str] = None

--- a/botx/models/command.py
+++ b/botx/models/command.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 class CommandDescriptor(BaseModel):
     """Bot command descriptor.
 
-    Used when defining a handler.
+    Used when defining a handler via decorators.
     """
 
     #: command body that will trigger command execution.

--- a/botx/models/command.py
+++ b/botx/models/command.py
@@ -1,0 +1,36 @@
+from typing import Optional, Sequence
+
+from pydantic import BaseModel, Field
+
+
+class CommandDescription(BaseModel):
+    #: command description that will be shown in a menu.
+    short: Optional[str] = None
+
+    #: full description that can be used for example in `/help`
+    full: Optional[str] = None
+
+
+class CommandDescriptor(BaseModel):
+    """Bot command descriptor.
+
+    Used when defining a handler.
+    """
+
+    #: command body that will trigger command execution.
+    command: Optional[str] = None
+
+    #: list of body command templates.
+    commands: Optional[Sequence[str]] = None
+
+    #: command name.
+    name: Optional[str] = None
+
+    #: command description that will be shown in a menu.
+    description: Optional[CommandDescription] = None
+
+
+# For user-defined code
+BotCommand = CommandDescriptor
+Description = CommandDescription
+

--- a/tests/test_collecting/test_collector/test_decorators/test_handler.py
+++ b/tests/test_collecting/test_collector/test_decorators/test_handler.py
@@ -1,5 +1,5 @@
 from botx import Collector
-from botx.models.command import CommandDescriptor, CommandDescription
+from botx.models.command import CommandDescriptor
 
 pytest_plugins = ("tests.test_collecting.fixtures",)
 
@@ -17,9 +17,9 @@ def test_handler_command_descriptor(
     handler_as_function, extract_collector, collector_cls,
 ):
     collector = collector_cls()
-    description = CommandDescription(short="short", full="full")
-    command_descriptor = CommandDescriptor(command="/test", name="name:test",
-                                           description=description)
+    command_descriptor = CommandDescriptor(
+        command="/test", name="name:test", description="short", full_description="full"
+    )
     collector.handler(command_descriptor=command_descriptor)(handler_as_function)
     handler = collector.handlers[0]
     assert handler.body == "/test"
@@ -28,13 +28,16 @@ def test_handler_command_descriptor(
     assert handler.description == "short"
 
 
-def test_handler_commands_descriptor(
+def test_handler_two_commands_descriptor(
     handler_as_function, extract_collector, collector_cls,
 ):
     collector = collector_cls()
-    description = CommandDescription(short="short", full="full")
-    command_descriptor = CommandDescriptor(commands=["/cmd1", "/cmd2"], name="name:test",
-                                           description=description)
+    command_descriptor = CommandDescriptor(
+        commands=["/cmd1", "/cmd2"],
+        name="name:test",
+        description="short",
+        full_description="full",
+    )
     collector.handler(command_descriptor=command_descriptor)(handler_as_function)
     assert collector.handlers[0].body == "/cmd1"
     assert collector.handlers[0].name == "name:test"

--- a/tests/test_collecting/test_collector/test_decorators/test_handler.py
+++ b/tests/test_collecting/test_collector/test_decorators/test_handler.py
@@ -1,4 +1,5 @@
 from botx import Collector
+from botx.models.command import CommandDescriptor, CommandDescription
 
 pytest_plugins = ("tests.test_collecting.fixtures",)
 
@@ -10,3 +11,37 @@ def test_defining_handler_in_collector_as_decorator(
     collector.handler()(handler_as_function)
     handlers = [collector.handler_for("handler_function")]
     assert handlers
+
+
+def test_handler_command_descriptor(
+    handler_as_function, extract_collector, collector_cls,
+):
+    collector = collector_cls()
+    description = CommandDescription(short="short", full="full")
+    command_descriptor = CommandDescriptor(command="/test", name="name:test",
+                                           description=description)
+    collector.handler(command_descriptor=command_descriptor)(handler_as_function)
+    handler = collector.handlers[0]
+    assert handler.body == "/test"
+    assert handler.name == "name:test"
+    assert handler.full_description == "full"
+    assert handler.description == "short"
+
+
+def test_handler_commands_descriptor(
+    handler_as_function, extract_collector, collector_cls,
+):
+    collector = collector_cls()
+    description = CommandDescription(short="short", full="full")
+    command_descriptor = CommandDescriptor(commands=["/cmd1", "/cmd2"], name="name:test",
+                                           description=description)
+    collector.handler(command_descriptor=command_descriptor)(handler_as_function)
+    assert collector.handlers[0].body == "/cmd1"
+    assert collector.handlers[0].name == "name:test"
+    assert collector.handlers[0].full_description == "full"
+    assert collector.handlers[0].description == "short"
+
+    assert collector.handlers[1].body == "/cmd2"
+    assert collector.handlers[1].name == "name:test"
+    assert collector.handlers[1].full_description == "full"
+    assert collector.handlers[1].description == "short"


### PR DESCRIPTION
Add a compound parameter object `command_descriptor` including `command`, `commands`, `name`, `description`. A single parameter, if any, has priority.