### PR TITLE
Fix dependencies in collector

### DIFF
--- a/botx/collecting/collectors/base.py
+++ b/botx/collecting/collectors/base.py
@@ -161,6 +161,9 @@ class BaseCollector:
         self, handlers: List[Handler], dependencies: Optional[Sequence[Depends]] = None,
     ) -> None:
         for handler in handlers:
+            combined_dependencies = _combine_dependencies(
+                dependencies, handler.dependencies,
+            )
             self.add_handler(
                 body=handler.body,
                 handler=handler.handler,
@@ -168,11 +171,7 @@ class BaseCollector:
                 description=handler.description,
                 full_description=handler.full_description,
                 include_in_status=handler.include_in_status,
-                dependencies=handler.dependencies,
-            )
-            created_handler = self.handler_for(handler.name)
-            created_handler.dependencies = _combine_dependencies(
-                dependencies, created_handler.dependencies,
+                dependencies=combined_dependencies,
             )
 
     def _add_default_handler(

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,10 @@
+## 0.16.9 (Dec 29, 2020)
+
+### Fixed
+
+* Dependencies added trought `include_collector` don't called
+
+
 ## 0.16.8 (Dec 24, 2020)
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "botx"
-version = "0.16.8"
+version = "0.16.9"
 description = "A little python framework for building bots for eXpress"
 license = "MIT"
 authors = ["Sidnev Nikolay <nsidnev@ccsteam.ru>"]

--- a/tests/test_collecting/test_collector/test_collectors_merging/test_dependencies_order.py
+++ b/tests/test_collecting/test_collector/test_collectors_merging/test_dependencies_order.py
@@ -60,3 +60,28 @@ def test_preserving_order_after_merging_for_default_handler(
     numbers = [dep.dependency.number for dep in handler.dependencies]
 
     assert numbers == [1, 2, 3]
+
+
+def test_dependencies_order_in_include_collector(
+    message, handler_as_function, build_dependency,
+):
+    message.command.body = "/command"
+
+    collector1 = Collector()
+    collector2 = Collector()
+
+    collector2.add_handler(
+        handler=handler_as_function,
+        body=message.command.command,
+        dependencies=[Depends(build_dependency(2))],
+    )
+
+    collector1.include_collector(
+        collector2, dependencies=[Depends(build_dependency(1))],
+    )
+
+    handler = collector1.handler_for("handler_function")
+
+    numbers = [dep.dependency.number for dep in handler.dependencies]
+
+    assert numbers == [1, 2]


### PR DESCRIPTION
Экзекутор для хендлера создается в `__post_init__` датакласса `Handler` в `botx/collecting/handlers/handler.py:78`
Сам датакласс `Handler` создается в `botx/collecting/collectors/base.py:BaseCollector:add_handler`
А зависимости, которые передаются в `include_collector` добавляются в `Handler` после инита в том же файле, функции `_add_handlers`.
Т.е. зависимости из `include_collector` не проходят `__post_init__` и соответственно не добавляются в экзекутор хендлера.
Для фикса я комбинирую зависимости в самом начале и передаю их в метод `add_handler`.