### PR TITLE
fix: File is now deleted when message is updated

### DIFF
--- a/botx/clients/methods/base.py
+++ b/botx/clients/methods/base.py
@@ -169,13 +169,16 @@ class BotXMethod(BaseBotXMethod[ResponseT], BaseModel, ABC):
             Serialized dict.
         """
         # TODO: Waiting for <https://github.com/samuelcolvin/pydantic/issues/1409/>
-        return json.loads(
+        serialized_dict = json.loads(
             self.json(
                 by_alias=True,
                 exclude=CREDENTIALS_FIELDS,
                 exclude_none=True,
             ),
         )
+        serialized_dict.update(self.dict(include={"file"}))
+
+        return serialized_dict
 
     def build_http_request(self) -> HTTPRequest:
         """Build HTTP request that can be used by clients for making real requests.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,7 +14,12 @@ Add `inserted_at` field to `ChatFromSearch` model
   `HTTPResponse` and will be useful in interceptors implementation.
 
 ### Removed
+
 * `HTTPResponse` bytes content property
+
+### Fixed
+
+* `File` is now deleted when the message is updated
 
 
 ## 0.19.1 (May 21, 2021)


### PR DESCRIPTION
The problem is parsing in json
There is a flag - exclude_none=True, therefore, when deleting a file, we have a payload.file=None and this field is simply thrown out of the request, and the server thinks that no action is required to be taken on the file and leaves it, if there is one