### PR TITLE
Fix BotDisabledResponse error_data validation

### DIFF
--- a/botx/models/errors.py
+++ b/botx/models/errors.py
@@ -1,8 +1,6 @@
 """Definition of errors in processing request from BotX API."""
 
-from typing import Any, Dict, List, Union
-
-from pydantic import validator
+from typing import List
 
 from botx.models.base import BotXBaseModel
 
@@ -21,30 +19,6 @@ class BotDisabledResponse(BotXBaseModel):
     reason: str = "bot_disabled"
 
     #: data about occurred error that should include `status_message` field in json.
-    error_data: Union[Dict[str, Any], BotDisabledErrorData]
+    error_data: BotDisabledErrorData
 
     errors: List[str] = []
-
-    @validator("error_data", always=True, each_item=True)
-    def status_message_in_error_data(
-        cls,
-        error_data: Dict[str, Any],  # noqa: N805
-    ) -> Union[BotDisabledErrorData, Dict[str, Any]]:
-        """Check that value contains `status_message` key or field.
-
-        Arguments:
-            error_data: value that should be checked.
-
-        Returns:
-            Built payload for response.
-
-        Raises:
-            ValueError: raised if error_data does not contain status_message.
-        """
-        if set(error_data.keys()) == {"status_message"}:
-            return BotDisabledErrorData(status_message=error_data["status_message"])
-
-        if "status_message" not in error_data:
-            raise ValueError("status_message key required in error_data")
-
-        return error_data

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,13 @@
+## 0.21.0 (Jul 23, 2021)
+
+Tested on BotX 1.42.0-rc4
+
+### Fixed
+
+* Remove `Dict[str, Any]` from type of `error_data` field of `BotDisabledResponse`,
+  now it can only be `BotDisabledErrorData`.
+
+
 ## 0.20.4 (Jul 23, 2021)
 
 Tested on BotX 1.42.0-rc4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "botx"
-version = "0.20.4"
+version = "0.21.0"
 description = "A little python framework for building bots for eXpress"
 license = "MIT"
 authors = [

--- a/tests/test_models/test_errors.py
+++ b/tests/test_models/test_errors.py
@@ -14,8 +14,3 @@ def test_doing_nothing_when_passed_error_data_model():
         error_data=BotDisabledErrorData(status_message="test"),
     )
     assert response.error_data.status_message == "test"
-
-
-def test_do_not_changing_right_shape():
-    extra_data = {"status_message": "test", "extra": True}
-    assert BotDisabledResponse(error_data=extra_data).error_data == extra_data


### PR DESCRIPTION
# Description

`BotDisabledErrorData.error_data` now can't be `Dict` and can only be `BotDisabledErrorData`
# Checklist

- [x] Linters and tests have passed
- [x] I've written a changelog for PR change
- [x] I'll make a release when PR is approved
