### PR TITLE
feature/skip_invalid_credentials

### DIFF
--- a/botx/bots/bots.py
+++ b/botx/bots/bots.py
@@ -132,12 +132,21 @@ class Bot(  # noqa: WPS215
 
         await self(msg)
 
-    async def authorize(self) -> None:
+    async def authorize(self, *args: Any) -> None:
         """Process auth for each bot account."""
         for account in self.bot_accounts:
-            token = await self.get_token(
-                account.host,
-                account.bot_id,
-                account.signature,
-            )
+            try:
+                token = await self.get_token(
+                    account.host,
+                    account.bot_id,
+                    account.signature,
+                )
+            except (exceptions.BotXAPIError, exceptions.BotXConnectError) as exc:
+                logger.bind(botx_bot=True).warning(
+                    f"Credentials `host - {account.host}, "  # noqa: WPS305
+                    f"bot_id - {account.bot_id}` are invalid. "
+                    f"Reason - {exc.message_template}",
+                )
+                continue
+
             account.token = token

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,10 @@
+## 0.21.3 (Aug 17, 2021)
+
+### Fixed
+
+* Bot's method `authorize()` now not fall if cant take some tokens. Just logging and skip invalid credentials.
+
+
 ## 0.21.2 (Aug 3, 2021)
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "botx"
-version = "0.21.2"
+version = "0.21.3"
 description = "A little python framework for building bots for eXpress"
 license = "MIT"
 authors = [

--- a/tests/test_models/test_credentials.py
+++ b/tests/test_models/test_credentials.py
@@ -31,3 +31,18 @@ async def test_auth_to_each_known_account(bot, client) -> None:
 
     for account in bot.bot_accounts:
         assert account.token is not None
+
+
+@pytest.mark.asyncio()
+async def test_auth_with_wrong_credentials(bot, host) -> None:
+    bot_id = UUID("8dada2c8-67a6-4434-9dec-570d244e78ee")
+    bot.bot_accounts = [
+        BotXCredentials(
+            host=host,
+            secret_key="wrong_secret",
+            bot_id=bot_id,
+        ),
+    ]
+    await bot.authorize()
+
+    assert bot.bot_accounts[0].token is None


### PR DESCRIPTION
# Description

Botx now skipping invalid credentials

P.S.  `*args` in authorize are needed in order to use this method in `bot.startup_events`. See PR in Box after this were merged.

# Checklist

- [x] Linters and tests have passed
- [x] I've written a changelog for PR change
- [x] I'll make a release when PR is approved
