### PR TITLE
feat: add name param to `download_file` method

### DIFF
--- a/botx/bots/mixins/requests/files.py
+++ b/botx/bots/mixins/requests/files.py
@@ -50,12 +50,13 @@ class FilesRequestsMixin:
             credentials=credentials,
         )
 
-    async def download_file(
+    async def download_file(  # noqa: WPS211
         self: BotXMethodCallProtocol,
         credentials: SendingCredentials,
         file_id: UUID,
         group_chat_id: UUID,
         *,
+        file_name: Optional[str] = None,
         is_preview: bool = False,
     ) -> File:
         """Download file from the chat.
@@ -64,12 +65,13 @@ class FilesRequestsMixin:
             credentials: credentials for making request.
             file_id: ID of the file.
             group_chat_id: ID of the chat that accepts the file.
+            file_name: file name to be assigned instead of default name.
             is_preview: get preview or file.
 
         Returns:
             Downloaded file.
         """
-        return await self.call_method(
+        file = await self.call_method(
             DownloadFile(
                 file_id=file_id,
                 group_chat_id=group_chat_id,
@@ -77,3 +79,9 @@ class FilesRequestsMixin:
             ),
             credentials=credentials,
         )
+
+        if file_name:
+            ext = file.file_name.split(".", maxsplit=1)[1]
+            file.file_name = "{name}.{ext}".format(name=file_name, ext=ext)
+
+        return file

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,10 @@
+## 0.23.2 (Sep 09, 2021)
+
+### Added
+
+* Add `file_name` param to `download_file` method to provide ability to change the returned file name.
+
+
 ## 0.23.1 (Aug 30, 2021)
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "botx"
-version = "0.23.1"
+version = "0.23.2"
 description = "A little python framework for building bots for eXpress"
 license = "MIT"
 authors = [

--- a/tests/test_bots/test_mixins/test_requests/test_files.py
+++ b/tests/test_bots/test_mixins/test_requests/test_files.py
@@ -25,3 +25,14 @@ async def test_download_file(client, message):
     )
 
     assert isinstance(client.requests[0], DownloadFile)
+
+
+async def test_custom_filename(client, message):
+    file = await client.bot.download_file(
+        message.credentials,
+        file_id=uuid4(),
+        group_chat_id=uuid4(),
+        file_name="myname",
+    )
+
+    assert file.file_name == "myname.txt"


### PR DESCRIPTION
# Description

Added `file_name` param to `download_file` method to provide ability to change returned file name

# Checklist

- [x] Linters and tests have passed
- [x] I've written a changelog for PR change
- [x] I'll make a release when PR is approved
