### PR TITLE
feat: add `cts_login`  and `cts_logout` system events

### DIFF
--- a/botx/bots/mixins/collecting/system_events.py
+++ b/botx/bots/mixins/collecting/system_events.py
@@ -7,7 +7,7 @@ from botx.dependencies.models import Depends
 from botx.models.enums import SystemEvents
 
 
-class SystemEventsHandlerMixin:
+class SystemEventsHandlerMixin:  # noqa: WPS214
     """Mixin that defines handler decorator."""
 
     collector: Collector
@@ -160,6 +160,54 @@ class SystemEventsHandlerMixin:
             Passed in `handler` callable.
         """
         return self.collector.left_from_chat(
+            handler=handler,
+            dependencies=dependencies,
+            dependency_overrides_provider=dependency_overrides_provider,
+        )
+
+    def cts_login(
+        self,
+        handler: Optional[Callable] = None,
+        *,
+        dependencies: Optional[Sequence[Depends]] = None,
+        dependency_overrides_provider: Any = None,
+    ) -> Callable:
+        """Register handler for `cts_login` event.
+
+        Arguments:
+            handler: callable that will be used for executing handler.
+            dependencies: sequence of dependencies that should be executed before
+                handler.
+            dependency_overrides_provider: mock of callable for handler.
+
+        Returns:
+            Passed in `handler` callable.
+        """
+        return self.collector.cts_login(
+            handler=handler,
+            dependencies=dependencies,
+            dependency_overrides_provider=dependency_overrides_provider,
+        )
+
+    def cts_logout(
+        self,
+        handler: Optional[Callable] = None,
+        *,
+        dependencies: Optional[Sequence[Depends]] = None,
+        dependency_overrides_provider: Any = None,
+    ) -> Callable:
+        """Register handler for `cts_logout` event.
+
+        Arguments:
+            handler: callable that will be used for executing handler.
+            dependencies: sequence of dependencies that should be executed before
+                handler.
+            dependency_overrides_provider: mock of callable for handler.
+
+        Returns:
+            Passed in `handler` callable.
+        """
+        return self.collector.cts_logout(
             handler=handler,
             dependencies=dependencies,
             dependency_overrides_provider=dependency_overrides_provider,

--- a/botx/collecting/collectors/mixins/system_events.py
+++ b/botx/collecting/collectors/mixins/system_events.py
@@ -11,7 +11,7 @@ except ImportError:
     from typing_extensions import Protocol  # type: ignore  # noqa: WPS433, WPS440, F401
 
 
-class SystemEventsHandlerMixin:
+class SystemEventsHandlerMixin:  # noqa: WPS214
     """Mixin that defines system events handler decorator."""
 
     def system_event(  # noqa: WPS211
@@ -206,6 +206,58 @@ class SystemEventsHandlerMixin:
             handler=handler,
             event=SystemEvents.internal_bot_notification,
             name=SystemEvents.internal_bot_notification.value,
+            dependencies=dependencies,
+            dependency_overrides_provider=dependency_overrides_provider,
+        )
+
+    def cts_login(
+        self,
+        handler: Optional[Callable] = None,
+        *,
+        dependencies: Optional[Sequence[Depends]] = None,
+        dependency_overrides_provider: Any = None,
+    ) -> Callable:
+        """Register handler for `cts_login` event.
+
+        Arguments:
+            handler: callable that will be used for executing handler.
+            dependencies: sequence of dependencies that should be executed before
+                handler.
+            dependency_overrides_provider: mock of callable for handler.
+
+        Returns:
+            Passed in `handler` callable.
+        """
+        return self.system_event(
+            handler=handler,
+            event=SystemEvents.cts_login,
+            name=SystemEvents.cts_login.value,
+            dependencies=dependencies,
+            dependency_overrides_provider=dependency_overrides_provider,
+        )
+
+    def cts_logout(
+        self,
+        handler: Optional[Callable] = None,
+        *,
+        dependencies: Optional[Sequence[Depends]] = None,
+        dependency_overrides_provider: Any = None,
+    ) -> Callable:
+        """Register handler for `cts_logout` event.
+
+        Arguments:
+            handler: callable that will be used for executing handler.
+            dependencies: sequence of dependencies that should be executed before
+                handler.
+            dependency_overrides_provider: mock of callable for handler.
+
+        Returns:
+            Passed in `handler` callable.
+        """
+        return self.system_event(
+            handler=handler,
+            event=SystemEvents.cts_logout,
+            name=SystemEvents.cts_logout.value,
             dependencies=dependencies,
             dependency_overrides_provider=dependency_overrides_provider,
         )

--- a/botx/middlewares/ns.py
+++ b/botx/middlewares/ns.py
@@ -174,8 +174,9 @@ def get_chain_key_by_message(message: Message) -> Tuple[str, UUID, UUID, UUID]:
         RuntimeError: raised if key for chain can not be built.
     """
     # key is a tuple of (host, bot_id, chat_id, user_huid)
-    if message.user_huid is None:
+    if not (message.user_huid and message.group_chat_id):
         raise RuntimeError("key for chain can be obtained only for messages from users")
+
     return message.host, message.bot_id, message.group_chat_id, message.user_huid
 
 

--- a/botx/models/enums.py
+++ b/botx/models/enums.py
@@ -26,6 +26,12 @@ class SystemEvents(Enum):
     #: `system:internal_bot_notification` event
     internal_bot_notification = "system:internal_bot_notification"
 
+    #: `system:cts_login` event.
+    cts_login = "system:cts_login"
+
+    #: `system:cts_logout` event.
+    cts_logout = "system:cts_logout"
+
     #: `file_transfer` message.
     file_transfer = "file_transfer"
 

--- a/botx/models/events.py
+++ b/botx/models/events.py
@@ -60,6 +60,26 @@ class InternalBotNotificationEvent(BotXBaseModel):
     opts: Dict[str, Any]
 
 
+class CTSLoginEvent(BotXBaseModel):
+    """Shape for `system:cts_login` event data."""
+
+    #: huid of user which logged into CTS.
+    user_huid: UUID
+
+    #: CTS id.
+    cts_id: UUID
+
+
+class CTSLogoutEvent(BotXBaseModel):
+    """Shape for `system:cts_logout` event data."""
+
+    #: huid of user which logged out from CTS.
+    user_huid: UUID
+
+    #: CTS id.
+    cts_id: UUID
+
+
 # dict for validating shape for different events
 EVENTS_SHAPE_MAP: Mapping[SystemEvents, Type[BotXBaseModel]] = MappingProxyType(
     {
@@ -68,5 +88,7 @@ EVENTS_SHAPE_MAP: Mapping[SystemEvents, Type[BotXBaseModel]] = MappingProxyType(
         SystemEvents.deleted_from_chat: DeletedFromChatEvent,
         SystemEvents.left_from_chat: LeftFromChatEvent,
         SystemEvents.internal_bot_notification: InternalBotNotificationEvent,
+        SystemEvents.cts_login: CTSLoginEvent,
+        SystemEvents.cts_logout: CTSLogoutEvent,
     },
 )

--- a/botx/models/messages/incoming_message.py
+++ b/botx/models/messages/incoming_message.py
@@ -17,6 +17,8 @@ CommandDataType = Union[
     events.DeletedFromChatEvent,
     events.LeftFromChatEvent,
     events.InternalBotNotificationEvent,
+    events.CTSLoginEvent,
+    events.CTSLogoutEvent,
     Dict[str, Any],
 ]
 
@@ -83,10 +85,10 @@ class Sender(BaseModel):
     user_huid: Optional[UUID]
 
     #: chat id.
-    group_chat_id: UUID
+    group_chat_id: Optional[UUID]
 
     #: type of chat.
-    chat_type: ChatTypes
+    chat_type: Optional[ChatTypes]
 
     #: AD login of user.
     ad_login: Optional[str]

--- a/botx/models/messages/message.py
+++ b/botx/models/messages/message.py
@@ -89,10 +89,10 @@ class Message:
     ad_domain: Optional[str] = _user_proxy_property()
 
     #: ID of chat from which message was received.
-    group_chat_id: UUID = _user_proxy_property()
+    group_chat_id: Optional[UUID] = _user_proxy_property()
 
     #: type of chat.
-    chat_type: ChatTypes = _user_proxy_property()
+    chat_type: Optional[ChatTypes] = _user_proxy_property()
 
     #: host of CTS from which message was received.
     host: str = _user_proxy_property()

--- a/botx/testing/building/entites.py
+++ b/botx/testing/building/entites.py
@@ -143,6 +143,7 @@ class BuildEntityMixin:
             ValueError: raise if conflict of requirement arguments.
         """
         if message and not forward:
+            assert message.group_chat_id is not None
             forward = Forward(
                 group_chat_id=message.group_chat_id,
                 sender_huid=message.user_huid or uuid.uuid4(),

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,10 @@
+## 0.25.0 (Sep 17, 2021)
+
+### Added
+
+* `cts_login` and `cts_logout` system events.
+
+
 ## 0.24.0 (Sep 14, 2021)
 
 ### Removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "botx"
-version = "0.24.0"
+version = "0.25.0"
 description = "A little python framework for building bots for eXpress"
 license = "MIT"
 authors = [

--- a/tests/test_collecting/test_collector/test_decorators/test_system_event.py
+++ b/tests/test_collecting/test_collector/test_decorators/test_system_event.py
@@ -17,6 +17,8 @@ def test_registration_handler_for_several_system_events(
         SystemEvents.deleted_from_chat,
         SystemEvents.left_from_chat,
         SystemEvents.internal_bot_notification,
+        SystemEvents.cts_login,
+        SystemEvents.cts_logout,
     }
     collector = collector_cls()
     collector.system_event(
@@ -35,6 +37,8 @@ def test_registration_handler_for_several_system_events(
         SystemEvents.chat_created,
         SystemEvents.file_transfer,
         SystemEvents.left_from_chat,
+        SystemEvents.cts_login,
+        SystemEvents.cts_logout,
     ],
 )
 def test_defining_system_handler_in_collector_as_decorator(


### PR DESCRIPTION
# Description

Added `cts_login`  and `cts_logout` system events which are sent by botx when user joins or leaves corporate server.

# Checklist

- [x] Linters and tests have passed
- [x] I've written a changelog for PR change
- [x] I'll make a release when PR is approved
