### PR TITLE
Fix name BotAccount to BotAccountWithSecret.

### DIFF
--- a/tests/client/notifications_api/test_direct_notification.py
+++ b/tests/client/notifications_api/test_direct_notification.py
@@ -964,7 +964,7 @@ async def test__send_message__message_body_max_length_error_raised(
     httpx_client: httpx.AsyncClient,
     host: str,
     bot_id: UUID,
-    bot_account: BotAccount,
+    bot_account: BotAccountWithSecret,
 ) -> None:
     # - Arrange -
     too_long_body = "1" * 4097
@@ -1008,7 +1008,7 @@ async def test__send_message__message_body_max_length_succeed(
     httpx_client: httpx.AsyncClient,
     host: str,
     bot_id: UUID,
-    bot_account: BotAccount,
+    bot_account: BotAccountWithSecret,
 ) -> None:
     max_long_body = "1" * 4096
     endpoint = respx.post(


### PR DESCRIPTION
# Description

Fix `BotAccount` name error on `BotAccountWithSecret`

# Checklist

- [ ] Linters and tests have passed
- [ ] I've written a changelog for PR change
- [ ] I'll make a release when PR is approved
