### PR TITLE
Fix validation in BotApiStatusRecipient, now empty strings in query params processed correctly

### DIFF
--- a/botx/models/status.py
+++ b/botx/models/status.py
@@ -1,7 +1,8 @@
 from dataclasses import asdict, dataclass
-from typing import Any, Dict, List, NewType, Optional
+from typing import Any, Dict, List, NewType, Optional, Union
 from uuid import UUID
 
+from pydantic import validator
 from typing_extensions import Literal  # For python 3.7 support
 
 from botx.models.api_base import VerifiedPayloadBaseModel
@@ -42,6 +43,17 @@ class BotAPIStatusRecipient(VerifiedPayloadBaseModel):
     ad_domain: Optional[str]
     is_admin: Optional[bool]
     chat_type: APIChatTypes
+
+    @validator("ad_login", "ad_domain", "is_admin", pre=True)
+    @classmethod
+    def replace_empty_string(
+        cls,
+        field_value: Union[str, bool],
+    ) -> Union[str, bool, None]:
+        if field_value == "":
+            return None
+
+        return field_value
 
     def to_domain(self) -> StatusRecipient:
         return StatusRecipient(

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -170,6 +170,28 @@ async def test__raw_get_status__minimally_filled_succeed() -> None:
 
 
 @pytest.mark.asyncio
+async def test__raw_get_status__minimum_filled_succeed() -> None:
+    # - Arrange -
+    query = {
+        "ad_domain": "",
+        "ad_login": "",
+        "is_admin": "",
+        "bot_id": "34477998-c8c7-53e9-aa4b-66ea5182dc3f",
+        "chat_type": "group_chat",
+        "user_huid": "f16cdc5f-6366-5552-9ecd-c36290ab3d11",
+    }
+
+    built_bot = Bot(collectors=[HandlerCollector()], bot_accounts=[])
+
+    # - Act -
+    async with lifespan_wrapper(built_bot) as bot:
+        status = await bot.raw_get_status(query)
+
+    # - Assert -
+    assert status
+
+
+@pytest.mark.asyncio
 async def test__raw_get_status__maximum_filled_succeed() -> None:
     # - Arrange -
     query = {


### PR DESCRIPTION
Fix validation in `BotApiStatusRecipient` class.

# Description

Now empty strings from query params given to the `BotApiStatusRecipient` processed correctly.

Example: `GET /status?ad_domain=&ad_login=&bot_id=uuid&chat_type=group_chat&is_admin=&user_huid=uuid`

# Checklist

- [x] Linters and tests have passed
- [ ] I've written a changelog for PR change
- [ ] I'll make a release when PR is approved
