### PR TITLE
fix: Add handling of unknown type attachment.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "botx"
-version = "0.30.2"
+version = "0.30.3"
 description = "A python library for interacting with eXpress BotX API"
 authors = [
     "Sidnev Nikolay <nsidnev@ccsteam.ru>",

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -270,3 +270,24 @@ async def test__async_execute_raw_bot_command__file_attachments_types(
     # - Assert -
     assert incoming_message
     assert incoming_message.file == domain_attachment
+
+
+async def test__async_execute_raw_bot_command__unknown_attachment_type(
+    api_incoming_message_factory: Callable[..., Dict[str, Any]],
+    bot_account: BotAccountWithSecret,
+    loguru_caplog: pytest.LogCaptureFixture,
+) -> None:
+    # - Arrange -
+    unknown_attachment = {"data": {"foo": "bar"}, "type": "baz"}
+    payload = api_incoming_message_factory(attachment=unknown_attachment)
+
+    collector = HandlerCollector()
+
+    built_bot = Bot(collectors=[collector], bot_accounts=[bot_account])
+
+    # - Act -
+    async with lifespan_wrapper(built_bot) as bot:
+        bot.async_execute_raw_bot_command(payload)
+
+    # - Assert -
+    assert "Received unknown attachment type" in loguru_caplog.text


### PR DESCRIPTION
# Checklist

- Fix crash bot if type attachment is not support.

- [x] I've written good commit message for all commits
- [ ] I've split changes into separate commits where it's appropriate
- [ ] I've updated project version in `pyproject.toml`
- [ ] I'll make a release when PR is merged
