### PR TITLE
feature: Simplify attachments names, drop unnecessary field

### DIFF
--- a/pybotx/models/attachments.py
+++ b/pybotx/models/attachments.py
@@ -62,9 +62,7 @@ class AttachmentVoice(FileAttachmentBase):
 
 
 @dataclass
-class AttachmentLocation:
-    type: Literal[AttachmentTypes.LOCATION]
-
+class Location:
     name: str
     address: str
     latitude: str
@@ -72,16 +70,12 @@ class AttachmentLocation:
 
 
 @dataclass
-class AttachmentContact:
-    type: Literal[AttachmentTypes.CONTACT]
-
+class Contact:
     name: str
 
 
 @dataclass
-class AttachmentLink:
-    type: Literal[AttachmentTypes.LINK]
-
+class Link:
     url: str
     title: str
     preview: str
@@ -212,9 +206,9 @@ BotAPIAttachment = Union[
 
 IncomingAttachment = Union[
     IncomingFileAttachment,
-    AttachmentLocation,
-    AttachmentContact,
-    AttachmentLink,
+    Location,
+    Contact,
+    Link,
     Sticker,
 ]
 
@@ -283,8 +277,7 @@ def convert_api_attachment_to_domain(  # noqa: WPS212
         attachment_type = cast(Literal[AttachmentTypes.LOCATION], attachment_type)
         api_attachment = cast(BotAPIAttachmentLocation, api_attachment)
 
-        return AttachmentLocation(
-            type=attachment_type,
+        return Location(
             name=api_attachment.data.location_name,
             address=api_attachment.data.location_address,
             latitude=api_attachment.data.location_lat,
@@ -295,8 +288,7 @@ def convert_api_attachment_to_domain(  # noqa: WPS212
         attachment_type = cast(Literal[AttachmentTypes.CONTACT], attachment_type)
         api_attachment = cast(BotAPIAttachmentContact, api_attachment)
 
-        return AttachmentContact(
-            type=attachment_type,
+        return Contact(
             name=api_attachment.data.contact_name,
         )
 
@@ -304,8 +296,7 @@ def convert_api_attachment_to_domain(  # noqa: WPS212
         attachment_type = cast(Literal[AttachmentTypes.LINK], attachment_type)
         api_attachment = cast(BotAPIAttachmentLink, api_attachment)
 
-        return AttachmentLink(
-            type=attachment_type,
+        return Link(
             url=api_attachment.data.url,
             title=api_attachment.data.url_title,
             preview=api_attachment.data.url_preview,

--- a/pybotx/models/message/incoming_message.py
+++ b/pybotx/models/message/incoming_message.py
@@ -7,12 +7,12 @@ from pydantic import Field
 
 from pybotx.logger import logger
 from pybotx.models.attachments import (
-    AttachmentContact,
-    AttachmentLink,
-    AttachmentLocation,
     BotAPIAttachment,
+    Contact,
     FileAttachmentBase,
     IncomingFileAttachment,
+    Link,
+    Location,
     convert_api_attachment_to_domain,
 )
 from pybotx.models.base_command import (
@@ -26,7 +26,6 @@ from pybotx.models.base_command import (
 from pybotx.models.bot_account import BotAccount
 from pybotx.models.chats import Chat
 from pybotx.models.enums import (
-    AttachmentTypes,
     BotAPIEntityTypes,
     BotAPIMentionTypes,
     ClientPlatforms,
@@ -92,9 +91,9 @@ class IncomingMessage(BotCommandBase):
     forward: Optional[Forward] = None
     reply: Optional[Reply] = None
     file: Optional[IncomingFileAttachment] = None
-    location: Optional[AttachmentLocation] = None
-    contact: Optional[AttachmentContact] = None
-    link: Optional[AttachmentLink] = None
+    location: Optional[Location] = None
+    contact: Optional[Contact] = None
+    link: Optional[Link] = None
     sticker: Optional[Sticker] = None
 
     state: SimpleNamespace = field(default_factory=SimpleNamespace)
@@ -240,9 +239,9 @@ class BotAPIIncomingMessage(BotAPIBaseCommand):
         )
 
         file: Optional[IncomingFileAttachment] = None
-        location: Optional[AttachmentLocation] = None
-        contact: Optional[AttachmentContact] = None
-        link: Optional[AttachmentLink] = None
+        location: Optional[Location] = None
+        contact: Optional[Contact] = None
+        link: Optional[Link] = None
         sticker: Optional[Sticker] = None
 
         if self.attachments:
@@ -256,13 +255,13 @@ class BotAPIIncomingMessage(BotAPIBaseCommand):
                 )
                 if isinstance(attachment_domain, FileAttachmentBase):  # noqa: WPS223
                     file = attachment_domain
-                elif attachment_domain.type == AttachmentTypes.LOCATION:
+                elif isinstance(attachment_domain, Location):
                     location = attachment_domain
-                elif attachment_domain.type == AttachmentTypes.CONTACT:
+                elif isinstance(attachment_domain, Contact):
                     contact = attachment_domain
-                elif attachment_domain.type == AttachmentTypes.LINK:
+                elif isinstance(attachment_domain, Link):
                     link = attachment_domain
-                elif attachment_domain.type == AttachmentTypes.STICKER:
+                elif isinstance(attachment_domain, Sticker):
                     sticker = attachment_domain
                 else:
                     raise NotImplementedError

--- a/pybotx/models/stickers.py
+++ b/pybotx/models/stickers.py
@@ -1,10 +1,9 @@
 from dataclasses import dataclass
-from typing import List, Literal, Optional
+from typing import List, Optional
 from uuid import UUID
 
 from pybotx.async_buffer import AsyncBufferWritable
 from pybotx.bot.contextvars import bot_var
-from pybotx.models.enums import AttachmentTypes
 
 
 @dataclass
@@ -23,8 +22,6 @@ class Sticker:
     emoji: str
     image_link: str
     pack_id: UUID
-
-    type: Literal[AttachmentTypes.STICKER] = AttachmentTypes.STICKER
 
     async def download(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybotx"
-version = "0.40.1"
+version = "0.41.0"
 description = "A python library for interacting with eXpress BotX API"
 authors = [
     "Sidnev Nikolay <nsidnev@ccsteam.ru>",

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -14,14 +14,14 @@ from pybotx import (
     lifespan_wrapper,
 )
 from pybotx.models.attachments import (
-    AttachmentContact,
     AttachmentDocument,
     AttachmentImage,
-    AttachmentLink,
-    AttachmentLocation,
     AttachmentVideo,
     AttachmentVoice,
+    Contact,
     IncomingAttachment,
+    Link,
+    Location,
 )
 
 pytestmark = [
@@ -88,8 +88,7 @@ API_AND_DOMAIN_NON_FILE_ATTACHMENTS = (
                 "location_lng": 34.28833,
             },
         },
-        AttachmentLocation(
-            type=AttachmentTypes.LOCATION,
+        Location(
             name="Центр вселенной",
             address="Россия, Тверская область",
             latitude="58.04861",
@@ -106,8 +105,7 @@ API_AND_DOMAIN_NON_FILE_ATTACHMENTS = (
                 "content": "data:text/vcard;base64,eDnXAc1FEUB0VFEFctII3lRlRBcetROeFfduPmXxE/8=",
             },
         },
-        AttachmentContact(
-            type=AttachmentTypes.CONTACT,
+        Contact(
             name="Иванов Иван",
         ),
         "contact",
@@ -122,8 +120,7 @@ API_AND_DOMAIN_NON_FILE_ATTACHMENTS = (
                 "url_text": "Some text in link",
             },
         },
-        AttachmentLink(
-            type=AttachmentTypes.LINK,
+        Link(
             url="http://ya.ru/xxx",
             title="Header in link",
             preview="http://ya.ru/xxx.jpg",


### PR DESCRIPTION
# Checklist

- [x] I've written good commit message for all commits
- [ ] I've split changes into separate commits where it's appropriate
- [x] I've updated project version in `pyproject.toml`
- [x] I'll make a release when PR is merged
- [x] I'll bump `pybotx` in `async-box`