### PR TITLE
feat(deps): включение Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - dependencies

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,1 +1,0 @@
-{ "enabled": false }


### PR DESCRIPTION
Этот PR включает Dependabot от Github, что позволяет следить за актуальностью зависимостей в репозитории.
Dependabot будет раз в неделю сканировать репозиторий и открывать/актуализировать PRы по обновлению той или иной зависимости.

Пример как это выглядит:
https://github.com/iteco-labss/pybotx/pull/5

Ранее в репозитории работал Renovate бот, который был отключен 20 января 2022 в этом коммите: e670feb5004ecd23a1bff663c5e6fe16c7e901a1
Файл конфига Renovate был удалён в данном PR.