### PR TITLE
docs: remove documentation link from toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ authors = [
     "Arseniy Zhiltsov <arseniy.zhiltsov@ccsteam.ru>"
 ]
 readme = "README.md"
-documentation = "https://expressapp.github.io/pybotx"
 repository = "https://github.com/ExpressApp/pybotx"
 
 


### PR DESCRIPTION
## PR checklist

- [x] I've written good commit message for all commits
- [x] I've split changes into separate commits where it's appropriate
- [x] I've added the description of function to documentation
- [ ] I've updated project version in `pyproject.toml`
- [x] I'll make a release when PR is merged
- [ ] I'll bump `pybotx` in `bot-template`
