### PR TITLE
fix: Fixed convert chat type in method create_chat

### DIFF
--- a/pybotx/bot/bot.py
+++ b/pybotx/bot/bot.py
@@ -1300,7 +1300,7 @@ class Bot:
             self._bot_accounts_storage,
         )
 
-        payload = BotXAPICreateChatRequestPayload(
+        payload = BotXAPICreateChatRequestPayload.from_domain(
             name=name,
             chat_type=chat_type,
             members=huids,

--- a/pybotx/client/chats_api/create_chat.py
+++ b/pybotx/client/chats_api/create_chat.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal
+from typing import Literal, Union
 from uuid import UUID
 
 from pydantic import (
@@ -6,7 +6,6 @@ from pydantic import (
     ConfigDict,
     field_serializer,
     field_validator,
-    model_validator,
 )
 
 from pybotx.client.authorized_botx_method import AuthorizedBotXMethod
@@ -36,12 +35,31 @@ class BotXAPICreateChatRequestPayload(UnverifiedPayloadBaseModel):
     shared_history: Missing[bool]
     avatar: str | None = None
 
-    @model_validator(mode="before")
-    def _convert_chat_type(cls, values: dict[str, Any]) -> dict[str, Any]:
-        ct = values.get("chat_type")
-        if isinstance(ct, ChatTypes):
-            values["chat_type"] = convert_chat_type_from_domain(ct)
-        return values
+    @classmethod
+    def from_domain(
+        cls,
+        name: str,
+        chat_type: Union[APIChatTypes, ChatTypes],
+        members: list[UUID],
+        shared_history: Missing[bool],
+        description: str | None = None,
+        avatar: str | None = None,
+    ) -> "BotXAPICreateChatRequestPayload":
+        converted_chat_type = cls._convert_chat_type(chat_type)
+        return cls(
+            name=name,
+            chat_type=converted_chat_type,
+            members=members,
+            shared_history=shared_history,
+            description=description,
+            avatar=avatar,
+        )
+
+    @classmethod
+    def _convert_chat_type(cls, v: Union[APIChatTypes, ChatTypes]) -> APIChatTypes:
+        if isinstance(v, ChatTypes):
+            return convert_chat_type_from_domain(v)
+        return v
 
     @field_validator("avatar")
     def _validate_avatar(cls, v: str | None) -> str | None:

--- a/tests/client/chats_api/test_create_chat.py
+++ b/tests/client/chats_api/test_create_chat.py
@@ -7,6 +7,7 @@ import pytest
 from respx.router import MockRouter
 
 from pybotx import ChatCreationError, ChatCreationProhibitedError, ChatTypes
+from pybotx.missing import Undefined
 from tests.testkit import BotXRequest, error_payload, mock_botx, ok_payload
 
 pytestmark = [
@@ -215,20 +216,41 @@ def test__create_chat_payload__convert_chat_type_validator() -> None:
     from pybotx.client.chats_api.create_chat import BotXAPICreateChatRequestPayload
     from pybotx.models.enums import ChatTypes, APIChatTypes
 
-    # Test with ChatTypes enum
-    values = {"chat_type": ChatTypes.GROUP_CHAT}
-    result = BotXAPICreateChatRequestPayload._convert_chat_type(values)  # type: ignore[operator]
-    assert result["chat_type"] == APIChatTypes.GROUP_CHAT
+    # Arrange
+    name = "Test Chat"
+    description = "Test Description"
+    chat_type = ChatTypes.PERSONAL_CHAT
+    members = [UUID("2fc83441-366a-49ba-81fc-6c39f065bb58")]
+    shared_history = Undefined
+    avatar = None
 
-    # Test with non-ChatTypes value (should remain unchanged)
-    values = {"chat_type": APIChatTypes.CHAT}  # type: ignore[dict-item]
-    result = BotXAPICreateChatRequestPayload._convert_chat_type(values)  # type: ignore[operator]
-    assert result["chat_type"] == APIChatTypes.CHAT
+    # Act
+    payload = BotXAPICreateChatRequestPayload.from_domain(
+        name=name,
+        chat_type=chat_type,
+        members=members,
+        shared_history=shared_history,
+        description=description,
+        avatar=avatar,
+    )
 
-    # Test with missing chat_type key
-    values = {"name": "test"}  # type: ignore[dict-item]
-    result = BotXAPICreateChatRequestPayload._convert_chat_type(values)  # type: ignore[operator]
-    assert result == {"name": "test"}
+    # Assert
+    assert payload.name == name
+    assert payload.description == description
+    assert payload.chat_type == APIChatTypes.CHAT
+    assert payload.members == members
+
+    # Test with APIChatTypes
+    api_chat_type = APIChatTypes.CHANNEL
+    payload = BotXAPICreateChatRequestPayload.from_domain(
+        name=name,
+        chat_type=api_chat_type,
+        members=members,
+        shared_history=shared_history,
+        description=description,
+        avatar=avatar,
+    )
+    assert payload.chat_type == api_chat_type
 
 
 def test__create_chat_payload__serialize_chat_type_from_domain() -> None:


### PR DESCRIPTION
## PR checklist

- [x] I've written good commit message for all commits
- [ ] I've split changes into separate commits where it's appropriate
- [ ] I've added the description of function to documentation
- [ ] I've updated project version in `pyproject.toml`
- [ ] I'll make a release when PR is merged
- [ ] I'll bump `pybotx` in `bot-template`
