### PR TITLE
fix: voex result model + add VOEX_CALL Chat Type

### DIFF
--- a/pybotx/client/voex_api/get_call.py
+++ b/pybotx/client/voex_api/get_call.py
@@ -20,7 +20,7 @@ class BotXAPIGetCallRequestPayload(UnverifiedPayloadBaseModel):
 
 
 class BotXAPIGetCallResult(VerifiedPayloadBaseModel):
-    id: UUID
+    call_id: UUID
     members: list[UUID]
 
 
@@ -30,7 +30,7 @@ class BotXAPIGetCallResponsePayload(VerifiedPayloadBaseModel):
 
     def to_domain(self) -> Call:
         return Call(
-            id=self.result.id,
+            id=self.result.call_id,
             members=self.result.members,
         )
 

--- a/pybotx/client/voex_api/get_conference.py
+++ b/pybotx/client/voex_api/get_conference.py
@@ -20,7 +20,7 @@ class BotXAPIGetConferenceRequestPayload(UnverifiedPayloadBaseModel):
 
 
 class BotXAPIGetConferenceResult(VerifiedPayloadBaseModel):
-    id: UUID
+    call_id: UUID
     name: str
     link: str
     members: list[UUID]
@@ -32,7 +32,7 @@ class BotXAPIGetConferenceResponsePayload(VerifiedPayloadBaseModel):
 
     def to_domain(self) -> Conference:
         return Conference(
-            id=self.result.id,
+            id=self.result.call_id,
             name=self.result.name,
             link=self.result.link,
             members=self.result.members,

--- a/pybotx/models/conference.py
+++ b/pybotx/models/conference.py
@@ -6,5 +6,5 @@ from uuid import UUID
 class Conference:
     id: UUID
     name: str
-    link: str
+    link: str | None
     members: list[UUID]

--- a/pybotx/models/enums.py
+++ b/pybotx/models/enums.py
@@ -66,6 +66,7 @@ class ChatTypes(AutoName):
     GROUP_CHAT = auto()
     CHANNEL = auto()
     THREAD = auto()
+    VOEX_CALL = auto()
 
 
 class SyncSourceTypes(AutoName):
@@ -366,7 +367,7 @@ def convert_chat_type_to_domain(
         APIChatTypes.GROUP_CHAT: ChatTypes.GROUP_CHAT,
         APIChatTypes.CHANNEL: ChatTypes.CHANNEL,
         APIChatTypes.THREAD: ChatTypes.THREAD,
-        APIChatTypes.VOEX_CALL: ChatTypes.GROUP_CHAT,
+        APIChatTypes.VOEX_CALL: ChatTypes.VOEX_CALL,
     }
 
     converted_type: IncomingChatTypes | None


### PR DESCRIPTION
## PR checklist

- [x] I've written good commit message for all commits
- [x] I've split changes into separate commits where it's appropriate
- [x] I've added the description of function to documentation
- [x] I've updated project version in `pyproject.toml`
- [x] I'll make a release when PR is merged
- [x] I'll bump `pybotx` in `bot-template`

### Что изменено
1. Пофиксил result model для конференций (Call и Conference)
2. Добавил VOEX_CALL Chat Type, чтобы легче было выявлять именно конференция или нет

### Зачем
1. У меня была ошибка когда я делал get_conference.
2. Чтобы отличать VOEX от GROUP через message.type

### Как проверить
1. Теперь работает get_conference, с получением полных данных (мемберы, ссылка, наименование), или get_сall для списков мемберов.
2. Можно посмотреть message.type
